### PR TITLE
PEP 693: Update 3.12.0b4 release date

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -597,6 +597,8 @@ pep-0713.rst  @ambv
 pep-0714.rst  @dstufft
 pep-0715.rst  @dstufft
 pep-0719.rst  @Yhg1s
+# pep-0720.rst (reserved for https://github.com/python/peps/pull/3192)
+pep-0721.rst  @encukou
 # ...
 # pep-0754.txt
 # ...

--- a/pep-0383.txt
+++ b/pep-0383.txt
@@ -100,7 +100,7 @@ has the limitation that chosen representation only "works" if the data
 get converted back to bytes with the surrogateescape error handler
 also. Encoding the data with the locale's encoding and the (default)
 strict error handler will raise an exception, encoding them with UTF-8
-will produce non-sensical data.
+will produce nonsensical data.
 
 Data obtained from other sources may conflict with data produced
 by this PEP. Dealing with such conflicts is out of scope of the PEP.

--- a/pep-0421.txt
+++ b/pep-0421.txt
@@ -193,7 +193,7 @@ As already noted in `Version Format`_, values in
 ``sys.implementation`` are intended for use by the standard library.
 Constraining those values, essentially specifying an API for them,
 allows them to be used consistently, regardless of how they are
-otherwise implemented.  However, care should be take to not
+otherwise implemented.  However, care should be taken to not
 over-specify the constraints.
 
 
@@ -375,7 +375,7 @@ The Bigger Picture
 ==================
 
 It's worth noting again that this PEP is a small part of a larger
-on-going effort to identify the implementation-specific parts of Python
+ongoing effort to identify the implementation-specific parts of Python
 and mitigate their impact on alternate implementations.
 
 ``sys.implementation`` is a focal point for implementation-specific

--- a/pep-0529.txt
+++ b/pep-0529.txt
@@ -126,7 +126,7 @@ The use of utf-8 will not be configurable, except for the provision of a
 "legacy mode" flag to revert to the previous behaviour.
 
 The ``surrogateescape`` error mode does not apply here, as the concern is not
-about retaining non-sensical bytes. Any path returned from the operating system
+about retaining nonsensical bytes. Any path returned from the operating system
 will be valid Unicode, while invalid paths created by the user should raise a
 decoding error (currently these would raise ``OSError`` or a subclass).
 

--- a/pep-0689.rst
+++ b/pep-0689.rst
@@ -104,7 +104,7 @@ APIs (functions, types, etc.) in this tier will named with the ``PyUnstable_``
 prefix, with no leading underscore.
 
 They will be declared in headers used for public API (``Include/*.h``,
-rather than in a subdirectory like ``Include/ustable/``).
+rather than in a subdirectory like ``Include/unstable/``).
 
 Several rules for dealing with the unstable tier will be introduced:
 

--- a/pep-0693.rst
+++ b/pep-0693.rst
@@ -54,10 +54,10 @@ Actual:
   (No new features beyond this point.)
 - 3.12.0 beta 2: Tuesday, 2023-06-06
 - 3.12.0 beta 3: Monday, 2023-06-19
+- 3.12.0 beta 4: Tuesday, 2023-07-11
 
 Expected:
 
-- 3.12.0 beta 4: Monday, 2023-07-10
 - 3.12.0 candidate 1: Monday, 2023-07-31
 - 3.12.0 candidate 2: Monday, 2023-09-04
 - 3.12.0 final:  Monday, 2023-10-02

--- a/pep-0701.rst
+++ b/pep-0701.rst
@@ -229,7 +229,7 @@ The new tokens (``FSTRING_START``, ``FSTRING_MIDDLE``, ``FSTRING_END``) are defi
 :ref:`later in this document <701-new-tokens>`.
 
 This PEP leaves up to the implementation the level of f-string nesting allowed
-(f-strings withing the expression parts of other f-strings) but **specifies a
+(f-strings within the expression parts of other f-strings) but **specifies a
 lower bound of 5 levels of nesting**. This is to ensure that users can have a
 reasonable expectation of being able to nest f-strings with "reasonable" depth.
 This PEP implies that limiting nesting is **not part of the language

--- a/pep-0706.rst
+++ b/pep-0706.rst
@@ -346,7 +346,7 @@ argument/attribute, which specifies how errors are handled:
   so, for example, you still get ``TypeError`` if you pass ``None`` as the
   destination path.
 - With ``errorlevel=1`` (the default), all *non-fatal* errors are ignored.
-  (They may be logged to ``sys.stderr`` by setting the *degug*
+  (They may be logged to ``sys.stderr`` by setting the *debug*
   argument/attribute.)
   Which errors are *non-fatal* is not defined in documentation, but code treats
   ``ExtractionError`` as such. Specifically, it's these issues:

--- a/pep-0714.rst
+++ b/pep-0714.rst
@@ -123,7 +123,7 @@ read the :pep:`658` metadata from the key ``data-core-metadata`` if it is
 present. They **MAY** optionally use the legacy ``data-dist-info-metadata`` if
 it is present but ``data-core-metadata`` is not.
 
-Clients consuming the JSON represenation of the Simple API **MUST** read the
+Clients consuming the JSON representation of the Simple API **MUST** read the
 :pep:`658` metadata from the key ``core-metadata`` if it is present. They
 **MAY** optionally use the legacy ``dist-info-metadata`` key if it is present
 but ``core-metadata`` is not.
@@ -222,7 +222,7 @@ difficult to implement in a reasonable way.
 Only change the JSON key
 ------------------------
 
-The bug in pip only affects the JSON represenation of the Simple API, so we only
+The bug in pip only affects the JSON representation of the Simple API, so we only
 *need* to actually change the key in the JSON, and we could leave the existing
 HTML keys alone.
 
@@ -253,7 +253,7 @@ We recommend that servers *only* emit the newer keys, particularly for the JSON
 representation of the Simple API since the bug itself only affected JSON.
 
 Servers that wish to support :pep:`658` in clients that use HTML and have it
-implemened, can safely emit both keys *only* in HTML.
+implemented, can safely emit both keys *only* in HTML.
 
 Servers should not emit the old keys in JSON unless they know that no broken
 versions of pip will be used to access their server.

--- a/pep-0715.rst
+++ b/pep-0715.rst
@@ -71,7 +71,7 @@ Some observations from that issue:
 Given the above, this PEP proposes the removal of the ``bdist_egg`` format
 under the same justifications presented in :pep:`527`, namely:
 
-* Egg distributions are of of limited use to the broader ecosystem and
+* Egg distributions are of limited use to the broader ecosystem and
   therefore represent a non-reciprocal maintenance burden;
 * Having an additional built distribution format
   is confusing to end users, who may

--- a/pep-0721.rst
+++ b/pep-0721.rst
@@ -1,0 +1,203 @@
+PEP: 721
+Title: Using tarfile.data_filter for source distribution extraction
+Author: Petr Viktorin <encukou@gmail.com>
+PEP-Delegate: Paul Moore <p.f.moore@gmail.com>
+Status: Draft
+Type: Standards Track
+Topic: Packaging
+Content-Type: text/x-rst
+Requires: 706
+Created: 12-Jul-2023
+Python-Version: 3.12
+Post-History: `04-Jul-2023 <https://discuss.python.org/t/28928>`__,
+
+
+Abstract
+========
+
+Extracting a source distribution archive should normally use the ``data``
+filter added in :pep:`706`.
+We clarify details, and specify the behaviour for tools that cannot use the
+filter directly.
+
+
+Motivation
+==========
+
+The *source distribution* ``sdist`` is defined as a tar archive.
+
+The ``tar`` format is designed to capture all metadata of Unix-like files.
+Some of these are dangerous, unnecessary for source code, and/or
+platform-dependent.
+As explained in :pep:`706`, when extracting a tarball, one should always either
+limit the allowed features, or explicitly give the tarball total control.
+
+
+Rationale
+=========
+
+For source distributions, the ``data`` filter introduced in :pep:`706`
+is enough. It allows slightly more features than ``git`` and ``zip`` (both
+commonly used in packaging workflows).
+
+However, not all tools can use the ``data`` filter,
+so this PEP specifies an explicit set of expectations.
+The aim is that the current behaviour of ``pip download``
+and ``setuptools.archive_util.unpack_tarfile`` is valid,
+except cases deemed too dangerous to allow.
+Another consideration is ease of implementation for non-Python tools.
+
+
+Unpatched versions of Python
+----------------------------
+
+Tools are allowed to ignore this PEP when running on Python pithout tarfile
+filters.
+
+The feature has been backported to all versions of Python supported by
+``python.org``. Vendoring it in third-party libraries is tricky,
+and we should not force all tools to do so.
+This shifts the responsibility to keep up with security updates from the tools
+to the users.
+
+
+Permissions
+-----------
+
+Common tools (``git``, ``zip``) don't preserve Unix permissions (mode bits).
+Telling users to not rely on them in *sdists*, and allowing tools to handle
+them relatively freely, seems fair.
+
+The only exception is the *executable* permission.
+We recommend, but not require, that tools preserve it.
+Given that scripts are generally platform-specific, it seems fitting to
+say that keeping them executable is tool-specific behaviour.
+
+Note that while ``git`` preserves executability, ``zip`` (and thus ``wheel``)
+doesn't do it natively. (It is possible to encode it in “external attributes”,
+but Python's ``ZipFile.extract`` does not honour that.)
+
+
+Specification
+=============
+
+The following will be added to `the PyPA source distribution format spec <https://packaging.python.org/en/latest/specifications/source-distribution-format/>`_
+under a new heading, “*Source distribution archive features*”:
+
+Because extracting tar files as-is is dangerous, and the results are
+platform-specific, archive features of source distributions are limited.
+
+Unpacking with the data filter
+------------------------------
+
+When extracting a source distribution, tools MUST either use
+``tarfile.data_filter`` (e.g. ``TarFile.extractall(..., filter='data')``), OR
+follow the *Unpacking without the data filter* section below.
+
+As an exception, on Python interpreters without ``hasattr(tarfile, 'data_filter')``
+(:pep:`706`), tools that normally use that filter (directly on indirectly)
+MAY warn the user and ignore this specification.
+The trade-off between usability (e.g. fully trusting the archive) and
+security (e.g. refusing to unpack) is left up to the tool in this case.
+
+
+Unpacking without the data filter
+---------------------------------
+
+Tools that do not use the ``data`` filter directly (e.g. for backwards
+compatibility, allowing additional features, or not using Python) MUST follow
+this section.
+(At the time of this writing, the ``data`` filter also follows this section,
+but it may get out of sync in the future.)
+
+The following files are invalid in an ``sdist`` archive.
+Upon encountering such an entry, tools SHOULD notify the user,
+MUST NOT unpack the entry, and MAY abort with a failure:
+
+- Files that would be placed outside the destination directory.
+- Links (symbolic or hard) pointing outside the destination directory.
+- Device files (including pipes).
+
+The following are also invalid. Tools MAY treat them as above,
+but are NOT REQUIRED to do so:
+
+- Files with a ``..`` component in the filename or link target.
+- Links pointing to a file that is not part of the archive.
+
+Tools MAY unpack links (symbolic or hard) as regular files,
+using content from the archive.
+
+When extracting ``sdist`` archives:
+
+- Leading slashes in file names MUST be dropped.
+  (This is nowadays standard behaviour for ``tar`` unpacking.)
+- For each ``mode`` (Unix permission) bit, tools MUST either:
+
+  - use the platform's default for a new file/directory (respectively),
+  - set the bit according to the archive, or
+  - use the bit from ``rw-r--r--`` (``0o644``) for non-executable files or
+    ``rwxr-xr-x`` (``0o755``) for executable files and directories.
+
+- High ``mode`` bits (setuid, setgid, sticky) MUST be cleared.
+- It is RECOMMENDED to preserve the user *executable* bit.
+
+
+Further hints
+-------------
+
+Tool authors are encouraged to consider how *hints for further
+verification* in ``tarfile`` documentation apply for their tool.
+
+
+Backwards Compatibility
+=======================
+
+The existing behaviour is unspecified, and treated differently by different
+tools.
+This PEP makes the expectations explicit.
+
+There is no known case of backwards incompatibility, but some project out there
+probably does rely on details that aren't guaranteed.
+This PEP bans the most dangerous of those features, and the rest is
+made tool-specific.
+
+
+Security Implications
+=====================
+
+The recommended ``data`` filter is believed safe against common exploits,
+and is a single place to amend if flaws are found in the future.
+
+The explicit specification includes protections from the ``data`` filter.
+
+
+How to Teach This
+=================
+
+The PEP is aimed at authors of packaging tools, who should be fine with
+a PEP and an updated packaging spec.
+
+
+Reference Implementation
+========================
+
+TBD
+
+
+Rejected Ideas
+==============
+
+None yet.
+
+
+Open Issues
+===========
+
+None yet.
+
+
+Copyright
+=========
+
+This document is placed in the public domain or under the
+CC0-1.0-Universal license, whichever is more permissive.

--- a/pep-0721.rst
+++ b/pep-0721.rst
@@ -51,7 +51,7 @@ Another consideration is ease of implementation for non-Python tools.
 Unpatched versions of Python
 ----------------------------
 
-Tools are allowed to ignore this PEP when running on Python pithout tarfile
+Tools are allowed to ignore this PEP when running on Python without tarfile
 filters.
 
 The feature has been backported to all versions of Python supported by

--- a/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
+++ b/pep_sphinx_extensions/pep_processor/parsing/pep_banner_directive.py
@@ -94,7 +94,7 @@ class CanonicalPyPASpecBanner(PEPBanner):
     )
     admonition_post_text = (
         "See the `PyPA specification update process "
-        "<https://www.pypa.io/en/latest/specifications/#handling-fixes-and-other-minor-updates>`__ "
+        "<https://www.pypa.io/en/latest/specifications.html#handling-fixes-and-other-minor-updates>`__ "
         "for how to propose changes."
     )
     admonition_class = nodes.attention


### PR DESCRIPTION
Re: https://www.python.org/downloads/release/python-3120b4/

<!-- readthedocs-preview pep-previews start -->
----
:books: Documentation preview :books:: https://pep-previews--5.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->